### PR TITLE
fmp4: add muxer for fragmented MP4's.

### DIFF
--- a/examples/mp4_to_fmp4/main.go
+++ b/examples/mp4_to_fmp4/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"github.com/kerberos-io/joy4/av/avutil"
+	"github.com/kerberos-io/joy4/format"
+)
+
+func init() {
+	format.RegisterAll()
+}
+func main() {
+	muxer, err := avutil.Create("sintel_fragmentedz.fmp4")
+	if err != nil {
+		panic(err)
+	}
+	demuxer, _ := avutil.Open("sintel.mp4")
+	avutil.CopyFile(muxer, demuxer)
+
+	muxer.Close()
+	demuxer.Close()
+}

--- a/format/fmp4/handler.go
+++ b/format/fmp4/handler.go
@@ -1,0 +1,46 @@
+package fmp4
+
+import (
+	"bytes"
+	"io"
+	"log"
+
+	"github.com/kerberos-io/joy4/av"
+	"github.com/kerberos-io/joy4/av/avutil"
+	"github.com/kerberos-io/joy4/format/mp4/mp4io"
+)
+
+var CodecTypes = []av.CodecType{av.H264, av.AAC}
+
+func Handler(h *avutil.RegisterHandler) {
+	h.Ext = ".fmp4"
+
+	h.Probe = func(b []byte) bool {
+		probe_reader := bytes.NewReader(b)
+		var atoms []mp4io.Atom
+		var err error
+		if atoms, err = mp4io.ReadFileAtoms(probe_reader); err != nil {
+			log.Printf("fmp4: Probe(): errored on read file atoms when probing")
+			return false
+		}
+
+		for _, atom := range atoms {
+			if atom.Tag() == mp4io.MOOF {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	/*
+		h.ReaderDemuxer = func(r io.Reader) av.Demuxer {
+			return NewDemuxer(r.(io.ReadSeeker))
+		}
+	*/
+	h.WriterMuxer = func(w io.Writer) av.Muxer {
+		return NewMuxer(w.(io.WriteSeeker))
+	}
+
+	h.CodecTypes = CodecTypes
+}

--- a/format/fmp4/muxer.go
+++ b/format/fmp4/muxer.go
@@ -1,0 +1,450 @@
+package fmp4
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/kerberos-io/joy4/av"
+	"github.com/kerberos-io/joy4/codec/aacparser"
+	"github.com/kerberos-io/joy4/codec/h264parser"
+	"github.com/kerberos-io/joy4/format/mp4/mp4io"
+	"github.com/kerberos-io/joy4/utils/bits/pio"
+)
+
+type Muxer struct {
+	w       io.WriteSeeker
+	bufw    *bufio.Writer
+	wpos    int64
+	streams []*Stream
+
+	moof_seqnum uint32
+	// Streams must start with Keyframes / IDRs
+	// A keyframe is a complete sample that contains all information to produce a single image.
+	// All other samples are deltas w.r.t to the last keyframe that's why MP4's must
+	// always start with a keyframe because any other type of frame will have not point of reference.
+	// It does mean we lose some data but it was useless anyways.
+	// This is on the muxer & not on an individual stream to prevent audio (pre first keyframe) of making
+	// it into our MP4 essentially delaying the audio by a few seconds perhaps (depends on keyframe interval).
+	gotFirstKeyframe bool
+}
+
+func NewMuxer(w io.WriteSeeker) *Muxer {
+	return &Muxer{
+		w:    w,
+		bufw: bufio.NewWriterSize(w, pio.RecommendBufioSize),
+	}
+}
+
+func (self *Muxer) newStream(codec av.CodecData, trackId int) (err error) {
+	switch codec.Type() {
+	case av.H264, av.AAC:
+
+	default:
+		err = fmt.Errorf("mp4: codec type=%v is not supported", codec.Type())
+		return
+	}
+	stream := &Stream{
+		CodecData: codec,
+		Idx:       trackId,
+	}
+
+	stream.sample = &mp4io.SampleTable{
+		SampleDesc:    &mp4io.SampleDesc{},
+		TimeToSample:  &mp4io.TimeToSample{},
+		SampleToChunk: &mp4io.SampleToChunk{},
+		SampleSize:    &mp4io.SampleSize{},
+		ChunkOffset:   &mp4io.ChunkOffset{},
+	}
+
+	stream.trackAtom = &mp4io.Track{
+		Header: &mp4io.TrackHeader{
+			TrackId:  int32(len(self.streams) + 1),
+			Flags:    0x0003, // Track enabled | Track in movie
+			Duration: 0,      // fill later
+			Matrix:   [9]int32{0x10000, 0, 0, 0, 0x10000, 0, 0, 0, 0x40000000},
+		},
+		Media: &mp4io.Media{
+			Header: &mp4io.MediaHeader{
+				TimeScale: 0, // fill later
+				Duration:  0, // fill later
+				Language:  21956,
+			},
+			Info: &mp4io.MediaInfo{
+				Sample: stream.sample,
+				Data: &mp4io.DataInfo{
+					Refer: &mp4io.DataRefer{
+						Url: &mp4io.DataReferUrl{
+							Flags: 0x000001, // Self reference
+						},
+					},
+				},
+			},
+		},
+	}
+
+	switch codec.Type() {
+	case av.H264:
+		stream.sample.SyncSample = &mp4io.SyncSample{}
+	}
+
+	stream.timeScale = 12288 // 90000 //
+	stream.muxer = self
+	self.streams = append(self.streams, stream)
+
+	return
+}
+
+func (self *Stream) fillTrackAtom() (err error) {
+	self.trackAtom.Media.Header.TimeScale = int32(self.timeScale)
+	self.trackAtom.Media.Header.Duration = int32(self.duration)
+
+	if self.Type() == av.H264 {
+		codec := self.CodecData.(h264parser.CodecData)
+		width, height := codec.Width(), codec.Height()
+		self.sample.SampleDesc.AVC1Desc = &mp4io.AVC1Desc{
+			DataRefIdx:           1,
+			HorizontalResolution: 72,
+			VorizontalResolution: 72,
+			Width:                int16(width),
+			Height:               int16(height),
+			FrameCount:           1,
+			Depth:                24,
+			ColorTableId:         -1,
+			Conf:                 &mp4io.AVC1Conf{Data: codec.AVCDecoderConfRecordBytes()},
+		}
+		self.trackAtom.Media.Handler = &mp4io.HandlerRefer{
+			SubType: [4]byte{'v', 'i', 'd', 'e'},
+			Name:    []byte("Video Media Handler"),
+		}
+		self.trackAtom.Media.Info.Video = &mp4io.VideoMediaInfo{
+			Flags: 0x000001,
+		}
+		self.trackAtom.Header.TrackWidth = float64(width)
+		self.trackAtom.Header.TrackHeight = float64(height)
+
+	} else if self.Type() == av.AAC {
+		codec := self.CodecData.(aacparser.CodecData)
+		audioConfig := codec.MPEG4AudioConfigBytes()
+		self.sample.SampleDesc.MP4ADesc = &mp4io.MP4ADesc{
+			DataRefIdx:       2,
+			NumberOfChannels: int16(codec.ChannelLayout().Count()),
+			SampleSize:       int16(codec.SampleFormat().BytesPerSample()),
+			SampleRate:       float64(codec.SampleRate()),
+			Conf: &mp4io.ElemStreamDesc{
+				DecConfig: audioConfig,
+			},
+		}
+		self.trackAtom.Header.Volume = 1
+		self.trackAtom.Header.AlternateGroup = 1
+		self.trackAtom.Media.Handler = &mp4io.HandlerRefer{
+			SubType: [4]byte{'s', 'o', 'u', 'n'},
+			Name:    []byte{'S', 'o', 'u', 'n', 'd', 'H', 'a', 'n', 'd', 'l', 'e', 'r', 0},
+		}
+		self.trackAtom.Media.Info.Sound = &mp4io.SoundMediaInfo{}
+
+	} else {
+		err = fmt.Errorf("mp4: codec type=%d invalid", self.Type())
+	}
+
+	return
+}
+
+func (self *Muxer) WriteHeader(streams []av.CodecData) (err error) {
+	self.streams = []*Stream{}
+	for i, stream := range streams {
+		if err = self.newStream(stream, i+1); err != nil {
+			// no need to stop the recording if a codec doesnt match, still try to...
+		}
+	}
+	/*
+		https://www.w3.org/2013/12/byte-stream-format-registry/isobmff-byte-stream-format.html#h2_iso-init-segments
+		The user agent must run the end of stream algorithm with the error parameter set to "decode" if any of the following conditions are met:
+			- A File Type Box contains a major_brand or compatible_brand that the user agent does not support.
+			- A box or field in the Movie Header Box is encountered that violates the requirements mandated by the major_brand or one of the compatible_brands in the File Type Box.
+			- The tracks in the Movie Header Box contain samples (i.e. the entry_count in the stts, stsc or stco boxes are not set to zero).
+			- A Movie Extends (mvex) box is not contained in the Movie (moov) box to indicate that Movie Fragments are to be expected.
+	*/
+
+	moov := &mp4io.Movie{}
+	moov.Header = &mp4io.MovieHeader{
+		PreferredRate:     1,
+		PreferredVolume:   1,
+		Matrix:            [9]int32{0x10000, 0, 0, 0, 0x10000, 0, 0, 0, 0x40000000},
+		NextTrackId:       int32(len(self.streams)), // ffmpeg uses the last track id as the next track id, makes no sense
+		PreviewTime:       time.Date(1904, time.January, 1, 0, 0, 0, 0, time.UTC),
+		PreviewDuration:   time.Date(1904, time.January, 1, 0, 0, 0, 0, time.UTC),
+		PosterTime:        time.Date(1904, time.January, 1, 0, 0, 0, 0, time.UTC),
+		SelectionTime:     time.Date(1904, time.January, 1, 0, 0, 0, 0, time.UTC),
+		SelectionDuration: time.Date(1904, time.January, 1, 0, 0, 0, 0, time.UTC),
+		CurrentTime:       time.Date(1904, time.January, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	// Movie Extend MVEX is required for fragmented MP4s
+	trackExtends := make([]*mp4io.TrackExtend, 0)
+	for _, stream := range self.streams {
+		// Add an extension for every available track along with their track ids.
+		ext := &mp4io.TrackExtend{
+			TrackId:              uint32(stream.Idx),
+			DefaultSampleDescIdx: uint32(1),
+		}
+		trackExtends = append(trackExtends, ext)
+	}
+	moov.MovieExtend = &mp4io.MovieExtend{
+		Tracks: trackExtends,
+	}
+
+	// TODO(atom): write a parser of the User Data Box (udta)
+
+	maxDur := time.Duration(0)
+	timeScale := int64(10000)
+	for _, stream := range self.streams {
+		if err = stream.fillTrackAtom(); err != nil {
+			return
+		}
+		dur := stream.tsToTime(stream.duration)
+		stream.trackAtom.Header.Duration = int32(timeToTs(dur, timeScale))
+		if dur > maxDur {
+			maxDur = dur
+		}
+		moov.Tracks = append(moov.Tracks, stream.trackAtom)
+	}
+	moov.Header.TimeScale = int32(timeScale)
+	moov.Header.Duration = int32(timeToTs(maxDur, timeScale))
+
+	b := make([]byte, moov.Len())
+	moov.Marshal(b)
+	if _, err = self.w.Write(b); err != nil {
+		return
+	}
+
+	return
+}
+
+func (self *Stream) BuildTrackFragmentWithoutOffset() (trackFragment *mp4io.TrackFrag, err error) {
+	// new duration
+	newDts := self.dts
+
+	// Create TrackFragRunEntries
+	trackfragentries := make([]mp4io.TrackFragRunEntry, 0) // https://ffmpeg.org/pipermail/ffmpeg-devel/2014-November/164898.html
+	// Loop over all the samples and build the Track Fragment Entries.
+	// Each sample gets its own entry which essentially captures the duration of the sample
+	// and the location within the MDAT relative by the size of the sample.
+	for _, pkt := range self.pkts {
+
+		// Calculate the duration of the frame, if no previous frames were recorded then
+		// invent a timestamp (1ms) for it to make sure it's not 0.
+		var duration time.Duration
+		if self.lastpkt != nil {
+			duration = pkt.Time - self.lastpkt.Time
+		}
+
+		// Increment the decode timestamp for the next Track Fragment Decode Time (TFDT)
+		// Essentially it is the combination of the durations of the samples.
+		newDts += self.timeToTs(duration)
+
+		/*
+			if duration == 0 {
+				duration = 40 * time.Millisecond
+			}*/
+
+		// Audio tends to build very predictable packets due to its sampling rate
+		// A possible optimization would be to rely on the default flags instead.
+		// This requires looping over all packets and verifying the default size & duration.const
+		// Saves a few bytes for each trun entry and could be looked into.const
+		// Current behavior is to explicitly write all of the entries their size & duration.
+		entry := mp4io.TrackFragRunEntry{
+			Duration: uint32(self.timeToTs(duration)), // The timescaled duration e.g 2999
+			Size:     uint32(len(pkt.Data)),           // The length of the sample in bytes e.g 51677
+			Flags:    uint32(33554432),
+			Cts:      uint32(self.timeToTs(pkt.CompositionTime)), // Composition timestamp is typically for B-frames, which are not used in RTSP
+		}
+		trackfragentries = append(trackfragentries, entry)
+		self.lastpkt = pkt
+	}
+
+	// Build the Track Fragment
+	DefaultSampleFlags := uint32(0)
+	if self.Type().String() == "H264" {
+		DefaultSampleFlags = 16842752
+	} else {
+		// audio
+		DefaultSampleFlags = 33554432
+	}
+
+	// If no fragment entries are available, then just set the durations to 512
+	// TODO: demuxer bug for B-frames has the same dts
+	DefaultDuration := uint32(512)
+
+	// Set the track frag flags such that they include the flag for CTS
+	trackFragRunFlags := uint32(mp4io.TRUN_DATA_OFFSET | mp4io.TRUN_FIRST_SAMPLE_FLAGS | mp4io.TRUN_SAMPLE_SIZE | mp4io.TRUN_SAMPLE_DURATION)
+	if self.hasBFrames { // TODO: add check if video track
+		//trackFragRunFlags = trackFragRunFlags | mp4io.TRUN_SAMPLE_CTS
+		trackFragRunFlags = uint32(mp4io.TRUN_DATA_OFFSET | mp4io.TRUN_FIRST_SAMPLE_FLAGS | mp4io.TRUN_SAMPLE_SIZE | mp4io.TRUN_SAMPLE_CTS)
+		// TODO: in ffmpeg this is 33554432 for video track & none if audio
+	}
+
+	FirstSampleFlags := uint32(mp4io.TRUN_SAMPLE_SIZE | mp4io.TRUN_SAMPLE_DURATION) // mp4io.TRUN_DATA_OFFSET | mp4io.TRUN_FIRST_SAMPLE_FLAGS |
+	// The first packet is a b-frame so set the first sample flags to have a CTS.
+	if len(self.pkts) > 0 && self.pkts[0].CompositionTime > 0 {
+		FirstSampleFlags = uint32(mp4io.TRUN_SAMPLE_SIZE | mp4io.TRUN_SAMPLE_CTS)
+	}
+
+	trackFragment = &mp4io.TrackFrag{
+		Header: &mp4io.TrackFragHeader{
+			Version:         uint8(0),
+			Flags:           uint32(mp4io.TFHD_DEFAULT_FLAGS | mp4io.TFHD_DEFAULT_DURATION | mp4io.TFHD_DEFAULT_BASE_IS_MOOF), // uint32(131128),
+			TrackId:         uint32(self.Idx),
+			DefaultDuration: DefaultDuration,
+			DefaultFlags:    DefaultSampleFlags, // TODO: fix to real flags
+		},
+		DecodeTime: &mp4io.TrackFragDecodeTime{
+			Version:    uint8(1), // Decides whether 1 = 64bit, 0 = 32bit timestamp
+			Flags:      uint32(0),
+			DecodeTime: uint64(self.dts), // Decode timestamp timescaled
+		},
+		Run: &mp4io.TrackFragRun{
+			Version:          uint8(0),
+			Flags:            trackFragRunFlags, // The flags if 0 then no DataOffset & no FirstSampleFlags
+			DataOffset:       uint32(368),       // NOTE: this is rewritten later
+			FirstSampleFlags: FirstSampleFlags,
+			Entries:          trackfragentries,
+		},
+	}
+
+	// Set the next dts
+	newDts += self.timeToTs(1 * time.Millisecond)
+	self.dts = newDts
+
+	// Reset hasBFrames
+	self.hasBFrames = false
+
+	return
+}
+
+func (self *Muxer) flushMoof() (err error) {
+
+	// Build the Track Frags
+	trackFragments := make([]*mp4io.TrackFrag, 0)
+	for _, stream := range self.streams {
+		// Build the Track Frag for this stream
+		var trackFragment *mp4io.TrackFrag
+		trackFragment, err = stream.BuildTrackFragmentWithoutOffset()
+		if err != nil {
+			return
+		}
+		trackFragments = append(trackFragments, trackFragment)
+	}
+
+	// Defer the clearing of the packets, we'll need them later in this function to
+	// write the MDAT contents & calculate its size.
+	defer func() {
+		for _, stream := range self.streams {
+			stream.pkts = make([]*av.Packet, 0)
+		}
+	}()
+
+	moof := &mp4io.MovieFrag{
+		Header: &mp4io.MovieFragHeader{
+			Version: uint8(0),
+			Flags:   uint32(0),
+			Seqnum:  self.moof_seqnum,
+		},
+		Tracks: trackFragments,
+	}
+
+	// Fix the dataoffsets of the track run
+	nextDataOffset := uint32(moof.Len() + 8)
+	for _, track := range moof.Tracks {
+		track.Run.DataOffset = nextDataOffset
+		for _, entry := range track.Run.Entries {
+			nextDataOffset += entry.Size
+		}
+	}
+
+	// Write the MOOF
+	b := make([]byte, moof.Len())
+	moof.Marshal(b)
+	if _, err = self.w.Write(b); err != nil {
+		return
+	}
+	b = nil
+
+	// Write the MDAT size
+	mdatsize := uint32(8) // skip itself
+	for _, fragment := range trackFragments {
+		for _, entry := range fragment.Run.Entries {
+			mdatsize += entry.Size
+		}
+	}
+
+	taghdr := make([]byte, 4)
+	pio.PutU32BE(taghdr, mdatsize)
+	if _, err = self.w.Write(taghdr); err != nil {
+		return
+	}
+	taghdr = nil
+
+	// Write the MDAT header
+	taghdr = make([]byte, 4)
+	pio.PutU32BE(taghdr, uint32(mp4io.MDAT))
+	if _, err = self.w.Write(taghdr); err != nil {
+		return
+	}
+	taghdr = nil
+
+	// Write the MDAT contents
+	for _, stream := range self.streams {
+		for _, pkt := range stream.pkts {
+			if _, err = self.w.Write(pkt.Data); err != nil {
+				return
+			}
+		}
+	}
+
+	// Increment the SeqNum
+	self.moof_seqnum++
+
+	return
+}
+
+func (self *Muxer) WritePacket(pkt av.Packet) (err error) {
+	// Check if pkt.Idx is a valid stream
+	if len(self.streams) < int(pkt.Idx+1) {
+		return
+	}
+	stream := self.streams[pkt.Idx]
+
+	// Wait until we have a video packet & it's a keyframe
+	if pkt.IsKeyFrame && !self.gotFirstKeyframe && stream.Type().IsVideo() {
+		// First keyframe found, we can start processing
+		self.gotFirstKeyframe = true
+	} else if !self.gotFirstKeyframe {
+		// Skip all packets until keyframe first
+		return
+	} else if pkt.IsKeyFrame {
+		// At this point, we have a keyframe and had one before.
+		self.flushMoof()
+	}
+
+	if err = stream.writePacket(pkt); err != nil {
+		return
+	}
+
+	return
+}
+
+func (self *Stream) writePacket(pkt av.Packet /*, rawdur time.Duration*/) (err error) {
+	self.pkts = append(self.pkts, &pkt)
+	// Optimization: set the has B Frames boolean to indicate that there are B-Frames
+	// that require the TrackFragRun will require the CTS flags.
+	self.hasBFrames = self.hasBFrames || pkt.CompositionTime > 0
+	return
+}
+
+func (self *Muxer) WriteTrailer() (err error) {
+	self.bufw = nil
+	self.streams = nil
+	return
+}

--- a/format/fmp4/stream.go
+++ b/format/fmp4/stream.go
@@ -1,0 +1,45 @@
+package fmp4
+
+import (
+	"time"
+
+	"github.com/kerberos-io/joy4/av"
+	"github.com/kerberos-io/joy4/format/mp4/mp4io"
+)
+
+type Stream struct {
+	av.CodecData
+
+	trackAtom *mp4io.Track
+	Idx       int
+
+	// pkts to be used in MDAT and MOOF > TRAF > TRUN
+	lastpkt    *av.Packet
+	pkts       []*av.Packet
+	hasBFrames bool
+
+	timeScale int64
+	duration  int64
+
+	muxer *Muxer
+	//demuxer *Demuxer
+
+	sample *mp4io.SampleTable
+	dts    int64
+}
+
+func timeToTs(tm time.Duration, timeScale int64) int64 {
+	return int64(tm * time.Duration(timeScale) / time.Second)
+}
+
+func tsToTime(ts int64, timeScale int64) time.Duration {
+	return time.Duration(ts) * time.Second / time.Duration(timeScale)
+}
+
+func (self *Stream) timeToTs(tm time.Duration) int64 {
+	return int64(tm * time.Duration(self.timeScale) / time.Second)
+}
+
+func (self *Stream) tsToTime(ts int64) time.Duration {
+	return time.Duration(ts) * time.Second / time.Duration(self.timeScale)
+}

--- a/format/format.go
+++ b/format/format.go
@@ -1,21 +1,22 @@
 package format
 
 import (
+	"github.com/kerberos-io/joy4/av/avutil"
+	"github.com/kerberos-io/joy4/format/aac"
+	"github.com/kerberos-io/joy4/format/flv"
+	"github.com/kerberos-io/joy4/format/fmp4"
 	"github.com/kerberos-io/joy4/format/mp4"
-	"github.com/kerberos-io/joy4/format/ts"
 	"github.com/kerberos-io/joy4/format/rtmp"
 	"github.com/kerberos-io/joy4/format/rtsp"
-	"github.com/kerberos-io/joy4/format/flv"
-	"github.com/kerberos-io/joy4/format/aac"
-	"github.com/kerberos-io/joy4/av/avutil"
+	"github.com/kerberos-io/joy4/format/ts"
 )
 
 func RegisterAll() {
 	avutil.DefaultHandlers.Add(mp4.Handler)
+	avutil.DefaultHandlers.Add(fmp4.Handler)
 	avutil.DefaultHandlers.Add(ts.Handler)
 	avutil.DefaultHandlers.Add(rtmp.Handler)
 	avutil.DefaultHandlers.Add(rtsp.Handler)
 	avutil.DefaultHandlers.Add(flv.Handler)
 	avutil.DefaultHandlers.Add(aac.Handler)
 }
-

--- a/format/mp4/mp4io/atoms.go
+++ b/format/mp4/mp4io/atoms.go
@@ -1,7 +1,10 @@
 package mp4io
 
-import "github.com/kerberos-io/joy4/utils/bits/pio"
-import "time"
+import (
+	"time"
+
+	"github.com/kerberos-io/joy4/utils/bits/pio"
+)
 
 const MOOF = Tag(0x6d6f6f66)
 
@@ -21,7 +24,7 @@ func (self AVC1Desc) Tag() Tag {
 	return AVC1
 }
 
-const URL  = Tag(0x75726c20)
+const URL = Tag(0x75726c20)
 
 func (self DataReferUrl) Tag() Tag {
 	return URL
@@ -204,16 +207,16 @@ func (self SoundMediaInfo) Tag() Tag {
 const MDAT = Tag(0x6d646174)
 
 type Movie struct {
-	Header		*MovieHeader
-	MovieExtend	*MovieExtend
-	Tracks		[]*Track
-	Unknowns	[]Atom
+	Header      *MovieHeader
+	MovieExtend *MovieExtend
+	Tracks      []*Track
+	Unknowns    []Atom
 	AtomPos
 }
 
 func (self Movie) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(MOOV))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -288,7 +291,7 @@ func (self *Movie) Unmarshal(b []byte, offset int) (n int, err error) {
 			}
 		default:
 			{
-				atom := &Dummy{Tag_: tag, Data: b[n:n+size]}
+				atom := &Dummy{Tag_: tag, Data: b[n : n+size]}
 				if _, err = atom.Unmarshal(b[n:n+size], offset+n); err != nil {
 					err = parseErr("", n+offset, err)
 					return
@@ -315,28 +318,28 @@ func (self Movie) Children() (r []Atom) {
 }
 
 type MovieHeader struct {
-	Version			uint8
-	Flags			uint32
-	CreateTime		time.Time
-	ModifyTime		time.Time
-	TimeScale		int32
-	Duration		int32
-	PreferredRate		float64
-	PreferredVolume		float64
-	Matrix			[9]int32
-	PreviewTime		time.Time
-	PreviewDuration		time.Time
-	PosterTime		time.Time
-	SelectionTime		time.Time
-	SelectionDuration	time.Time
-	CurrentTime		time.Time
-	NextTrackId		int32
+	Version           uint8
+	Flags             uint32
+	CreateTime        time.Time
+	ModifyTime        time.Time
+	TimeScale         int32
+	Duration          int32
+	PreferredRate     float64
+	PreferredVolume   float64
+	Matrix            [9]int32
+	PreviewTime       time.Time
+	PreviewDuration   time.Time
+	PosterTime        time.Time
+	SelectionTime     time.Time
+	SelectionDuration time.Time
+	CurrentTime       time.Time
+	NextTrackId       int32
 	AtomPos
 }
 
 func (self MovieHeader) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(MVHD))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -389,7 +392,7 @@ func (self MovieHeader) Len() (n int) {
 	n += 4
 	n += 2
 	n += 10
-	n += 4*len(self.Matrix[:])
+	n += 4 * len(self.Matrix[:])
 	n += 4
 	n += 4
 	n += 4
@@ -508,15 +511,15 @@ func (self MovieHeader) Children() (r []Atom) {
 }
 
 type Track struct {
-	Header		*TrackHeader
-	Media		*Media
-	Unknowns	[]Atom
+	Header   *TrackHeader
+	Media    *Media
+	Unknowns []Atom
 	AtomPos
 }
 
 func (self Track) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(TRAK))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -576,7 +579,7 @@ func (self *Track) Unmarshal(b []byte, offset int) (n int, err error) {
 			}
 		default:
 			{
-				atom := &Dummy{Tag_: tag, Data: b[n:n+size]}
+				atom := &Dummy{Tag_: tag, Data: b[n : n+size]}
 				if _, err = atom.Unmarshal(b[n:n+size], offset+n); err != nil {
 					err = parseErr("", n+offset, err)
 					return
@@ -600,24 +603,24 @@ func (self Track) Children() (r []Atom) {
 }
 
 type TrackHeader struct {
-	Version		uint8
-	Flags		uint32
-	CreateTime	time.Time
-	ModifyTime	time.Time
-	TrackId		int32
-	Duration	int32
-	Layer		int16
-	AlternateGroup	int16
-	Volume		float64
-	Matrix		[9]int32
-	TrackWidth	float64
-	TrackHeight	float64
+	Version        uint8
+	Flags          uint32
+	CreateTime     time.Time
+	ModifyTime     time.Time
+	TrackId        int32
+	Duration       int32
+	Layer          int16
+	AlternateGroup int16
+	Volume         float64
+	Matrix         [9]int32
+	TrackWidth     float64
+	TrackHeight    float64
 	AtomPos
 }
 
 func (self TrackHeader) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(TKHD))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -667,7 +670,7 @@ func (self TrackHeader) Len() (n int) {
 	n += 2
 	n += 2
 	n += 2
-	n += 4*len(self.Matrix[:])
+	n += 4 * len(self.Matrix[:])
 	n += 4
 	n += 4
 	return
@@ -759,17 +762,17 @@ func (self TrackHeader) Children() (r []Atom) {
 }
 
 type HandlerRefer struct {
-	Version	uint8
-	Flags	uint32
-	Type	[4]byte
-	SubType	[4]byte
-	Name	[]byte
+	Version uint8
+	Flags   uint32
+	Type    [4]byte
+	SubType [4]byte
+	Name    []byte
 	AtomPos
 }
 
 func (self HandlerRefer) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(HDLR))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -782,6 +785,13 @@ func (self HandlerRefer) marshal(b []byte) (n int) {
 	n += len(self.Type[:])
 	copy(b[n:], self.SubType[:])
 	n += len(self.SubType[:])
+	// TODO: document component
+	pio.PutU32BE(b[n:], uint32(0))
+	n += 4
+	pio.PutU32BE(b[n:], uint32(0))
+	n += 4
+	pio.PutU32BE(b[n:], uint32(0))
+	n += 4
 	copy(b[n:], self.Name[:])
 	n += len(self.Name[:])
 	return
@@ -792,6 +802,10 @@ func (self HandlerRefer) Len() (n int) {
 	n += 3
 	n += len(self.Type[:])
 	n += len(self.SubType[:])
+	// TODO: document component
+	n += 4
+	n += 4
+	n += 4
 	n += len(self.Name[:])
 	return
 }
@@ -822,6 +836,10 @@ func (self *HandlerRefer) Unmarshal(b []byte, offset int) (n int, err error) {
 	}
 	copy(self.SubType[:], b[n:])
 	n += len(self.SubType)
+	// TODO: document component
+	n += 4
+	n += 4
+	n += 4
 	self.Name = b[n:]
 	n += len(b[n:])
 	return
@@ -831,16 +849,16 @@ func (self HandlerRefer) Children() (r []Atom) {
 }
 
 type Media struct {
-	Header		*MediaHeader
-	Handler		*HandlerRefer
-	Info		*MediaInfo
-	Unknowns	[]Atom
+	Header   *MediaHeader
+	Handler  *HandlerRefer
+	Info     *MediaInfo
+	Unknowns []Atom
 	AtomPos
 }
 
 func (self Media) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(MDIA))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -915,7 +933,7 @@ func (self *Media) Unmarshal(b []byte, offset int) (n int, err error) {
 			}
 		default:
 			{
-				atom := &Dummy{Tag_: tag, Data: b[n:n+size]}
+				atom := &Dummy{Tag_: tag, Data: b[n : n+size]}
 				if _, err = atom.Unmarshal(b[n:n+size], offset+n); err != nil {
 					err = parseErr("", n+offset, err)
 					return
@@ -942,20 +960,20 @@ func (self Media) Children() (r []Atom) {
 }
 
 type MediaHeader struct {
-	Version		uint8
-	Flags		uint32
-	CreateTime	time.Time
-	ModifyTime	time.Time
-	TimeScale	int32
-	Duration	int32
-	Language	int16
-	Quality		int16
+	Version    uint8
+	Flags      uint32
+	CreateTime time.Time
+	ModifyTime time.Time
+	TimeScale  int32
+	Duration   int32
+	Language   int16
+	Quality    int16
 	AtomPos
 }
 
 func (self MediaHeader) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(MDHD))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -1048,17 +1066,17 @@ func (self MediaHeader) Children() (r []Atom) {
 }
 
 type MediaInfo struct {
-	Sound		*SoundMediaInfo
-	Video		*VideoMediaInfo
-	Data		*DataInfo
-	Sample		*SampleTable
-	Unknowns	[]Atom
+	Sound    *SoundMediaInfo
+	Video    *VideoMediaInfo
+	Data     *DataInfo
+	Sample   *SampleTable
+	Unknowns []Atom
 	AtomPos
 }
 
 func (self MediaInfo) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(MINF))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -1148,7 +1166,7 @@ func (self *MediaInfo) Unmarshal(b []byte, offset int) (n int, err error) {
 			}
 		default:
 			{
-				atom := &Dummy{Tag_: tag, Data: b[n:n+size]}
+				atom := &Dummy{Tag_: tag, Data: b[n : n+size]}
 				if _, err = atom.Unmarshal(b[n:n+size], offset+n); err != nil {
 					err = parseErr("", n+offset, err)
 					return
@@ -1178,14 +1196,14 @@ func (self MediaInfo) Children() (r []Atom) {
 }
 
 type DataInfo struct {
-	Refer		*DataRefer
-	Unknowns	[]Atom
+	Refer    *DataRefer
+	Unknowns []Atom
 	AtomPos
 }
 
 func (self DataInfo) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(DINF))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -1230,7 +1248,7 @@ func (self *DataInfo) Unmarshal(b []byte, offset int) (n int, err error) {
 			}
 		default:
 			{
-				atom := &Dummy{Tag_: tag, Data: b[n:n+size]}
+				atom := &Dummy{Tag_: tag, Data: b[n : n+size]}
 				if _, err = atom.Unmarshal(b[n:n+size], offset+n); err != nil {
 					err = parseErr("", n+offset, err)
 					return
@@ -1251,15 +1269,15 @@ func (self DataInfo) Children() (r []Atom) {
 }
 
 type DataRefer struct {
-	Version	uint8
-	Flags	uint32
-	Url	*DataReferUrl
+	Version uint8
+	Flags   uint32
+	Url     *DataReferUrl
 	AtomPos
 }
 
 func (self DataRefer) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(DREF))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -1313,7 +1331,7 @@ func (self *DataRefer) Unmarshal(b []byte, offset int) (n int, err error) {
 			return
 		}
 		switch tag {
-		case URL :
+		case URL:
 			{
 				atom := &DataReferUrl{}
 				if _, err = atom.Unmarshal(b[n:n+size], offset+n); err != nil {
@@ -1335,14 +1353,14 @@ func (self DataRefer) Children() (r []Atom) {
 }
 
 type DataReferUrl struct {
-	Version	uint8
-	Flags	uint32
+	Version uint8
+	Flags   uint32
 	AtomPos
 }
 
 func (self DataReferUrl) Marshal(b []byte) (n int) {
-	pio.PutU32BE(b[4:], uint32(URL ))
-	n += self.marshal(b[8:])+8
+	pio.PutU32BE(b[4:], uint32(URL))
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -1381,15 +1399,15 @@ func (self DataReferUrl) Children() (r []Atom) {
 }
 
 type SoundMediaInfo struct {
-	Version	uint8
-	Flags	uint32
-	Balance	int16
+	Version uint8
+	Flags   uint32
+	Balance int16
 	AtomPos
 }
 
 func (self SoundMediaInfo) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(SMHD))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -1440,16 +1458,16 @@ func (self SoundMediaInfo) Children() (r []Atom) {
 }
 
 type VideoMediaInfo struct {
-	Version		uint8
-	Flags		uint32
-	GraphicsMode	int16
-	Opcolor		[3]int16
+	Version      uint8
+	Flags        uint32
+	GraphicsMode int16
+	Opcolor      [3]int16
 	AtomPos
 }
 
 func (self VideoMediaInfo) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(VMHD))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -1471,7 +1489,7 @@ func (self VideoMediaInfo) Len() (n int) {
 	n += 1
 	n += 3
 	n += 2
-	n += 2*len(self.Opcolor[:])
+	n += 2 * len(self.Opcolor[:])
 	return
 }
 func (self *VideoMediaInfo) Unmarshal(b []byte, offset int) (n int, err error) {
@@ -1510,19 +1528,19 @@ func (self VideoMediaInfo) Children() (r []Atom) {
 }
 
 type SampleTable struct {
-	SampleDesc		*SampleDesc
-	TimeToSample		*TimeToSample
-	CompositionOffset	*CompositionOffset
-	SampleToChunk		*SampleToChunk
-	SyncSample		*SyncSample
-	ChunkOffset		*ChunkOffset
-	SampleSize		*SampleSize
+	SampleDesc        *SampleDesc
+	TimeToSample      *TimeToSample
+	CompositionOffset *CompositionOffset
+	SampleToChunk     *SampleToChunk
+	SyncSample        *SyncSample
+	ChunkOffset       *ChunkOffset
+	SampleSize        *SampleSize
 	AtomPos
 }
 
 func (self SampleTable) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(STBL))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -1680,16 +1698,16 @@ func (self SampleTable) Children() (r []Atom) {
 }
 
 type SampleDesc struct {
-	Version		uint8
-	AVC1Desc	*AVC1Desc
-	MP4ADesc	*MP4ADesc
-	Unknowns	[]Atom
+	Version  uint8
+	AVC1Desc *AVC1Desc
+	MP4ADesc *MP4ADesc
+	Unknowns []Atom
 	AtomPos
 }
 
 func (self SampleDesc) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(STSD))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -1773,7 +1791,7 @@ func (self *SampleDesc) Unmarshal(b []byte, offset int) (n int, err error) {
 			}
 		default:
 			{
-				atom := &Dummy{Tag_: tag, Data: b[n:n+size]}
+				atom := &Dummy{Tag_: tag, Data: b[n : n+size]}
 				if _, err = atom.Unmarshal(b[n:n+size], offset+n); err != nil {
 					err = parseErr("", n+offset, err)
 					return
@@ -1797,22 +1815,22 @@ func (self SampleDesc) Children() (r []Atom) {
 }
 
 type MP4ADesc struct {
-	DataRefIdx		int16
-	Version			int16
-	RevisionLevel		int16
-	Vendor			int32
-	NumberOfChannels	int16
-	SampleSize		int16
-	CompressionId		int16
-	SampleRate		float64
-	Conf			*ElemStreamDesc
-	Unknowns		[]Atom
+	DataRefIdx       int16
+	Version          int16
+	RevisionLevel    int16
+	Vendor           int32
+	NumberOfChannels int16
+	SampleSize       int16
+	CompressionId    int16
+	SampleRate       float64
+	Conf             *ElemStreamDesc
+	Unknowns         []Atom
 	AtomPos
 }
 
 func (self MP4ADesc) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(MP4A))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -1935,7 +1953,7 @@ func (self *MP4ADesc) Unmarshal(b []byte, offset int) (n int, err error) {
 			}
 		default:
 			{
-				atom := &Dummy{Tag_: tag, Data: b[n:n+size]}
+				atom := &Dummy{Tag_: tag, Data: b[n : n+size]}
 				if _, err = atom.Unmarshal(b[n:n+size], offset+n); err != nil {
 					err = parseErr("", n+offset, err)
 					return
@@ -1956,28 +1974,28 @@ func (self MP4ADesc) Children() (r []Atom) {
 }
 
 type AVC1Desc struct {
-	DataRefIdx		int16
-	Version			int16
-	Revision		int16
-	Vendor			int32
-	TemporalQuality		int32
-	SpatialQuality		int32
-	Width			int16
-	Height			int16
-	HorizontalResolution	float64
-	VorizontalResolution	float64
-	FrameCount		int16
-	CompressorName		[32]byte
-	Depth			int16
-	ColorTableId		int16
-	Conf			*AVC1Conf
-	Unknowns		[]Atom
+	DataRefIdx           int16
+	Version              int16
+	Revision             int16
+	Vendor               int32
+	TemporalQuality      int32
+	SpatialQuality       int32
+	Width                int16
+	Height               int16
+	HorizontalResolution float64
+	VorizontalResolution float64
+	FrameCount           int16
+	CompressorName       [32]byte
+	Depth                int16
+	ColorTableId         int16
+	Conf                 *AVC1Conf
+	Unknowns             []Atom
 	AtomPos
 }
 
 func (self AVC1Desc) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(AVC1))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -2154,7 +2172,7 @@ func (self *AVC1Desc) Unmarshal(b []byte, offset int) (n int, err error) {
 			}
 		default:
 			{
-				atom := &Dummy{Tag_: tag, Data: b[n:n+size]}
+				atom := &Dummy{Tag_: tag, Data: b[n : n+size]}
 				if _, err = atom.Unmarshal(b[n:n+size], offset+n); err != nil {
 					err = parseErr("", n+offset, err)
 					return
@@ -2175,13 +2193,13 @@ func (self AVC1Desc) Children() (r []Atom) {
 }
 
 type AVC1Conf struct {
-	Data	[]byte
+	Data []byte
 	AtomPos
 }
 
 func (self AVC1Conf) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(AVCC))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -2207,15 +2225,15 @@ func (self AVC1Conf) Children() (r []Atom) {
 }
 
 type TimeToSample struct {
-	Version	uint8
-	Flags	uint32
-	Entries	[]TimeToSampleEntry
+	Version uint8
+	Flags   uint32
+	Entries []TimeToSampleEntry
 	AtomPos
 }
 
 func (self TimeToSample) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(STTS))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -2237,7 +2255,7 @@ func (self TimeToSample) Len() (n int) {
 	n += 1
 	n += 3
 	n += 4
-	n += LenTimeToSampleEntry*len(self.Entries)
+	n += LenTimeToSampleEntry * len(self.Entries)
 	return
 }
 func (self *TimeToSample) Unmarshal(b []byte, offset int) (n int, err error) {
@@ -2274,8 +2292,8 @@ func (self TimeToSample) Children() (r []Atom) {
 }
 
 type TimeToSampleEntry struct {
-	Count		uint32
-	Duration	uint32
+	Count    uint32
+	Duration uint32
 }
 
 func GetTimeToSampleEntry(b []byte) (self TimeToSampleEntry) {
@@ -2291,15 +2309,15 @@ func PutTimeToSampleEntry(b []byte, self TimeToSampleEntry) {
 const LenTimeToSampleEntry = 8
 
 type SampleToChunk struct {
-	Version	uint8
-	Flags	uint32
-	Entries	[]SampleToChunkEntry
+	Version uint8
+	Flags   uint32
+	Entries []SampleToChunkEntry
 	AtomPos
 }
 
 func (self SampleToChunk) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(STSC))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -2321,7 +2339,7 @@ func (self SampleToChunk) Len() (n int) {
 	n += 1
 	n += 3
 	n += 4
-	n += LenSampleToChunkEntry*len(self.Entries)
+	n += LenSampleToChunkEntry * len(self.Entries)
 	return
 }
 func (self *SampleToChunk) Unmarshal(b []byte, offset int) (n int, err error) {
@@ -2358,9 +2376,9 @@ func (self SampleToChunk) Children() (r []Atom) {
 }
 
 type SampleToChunkEntry struct {
-	FirstChunk	uint32
-	SamplesPerChunk	uint32
-	SampleDescId	uint32
+	FirstChunk      uint32
+	SamplesPerChunk uint32
+	SampleDescId    uint32
 }
 
 func GetSampleToChunkEntry(b []byte) (self SampleToChunkEntry) {
@@ -2378,15 +2396,15 @@ func PutSampleToChunkEntry(b []byte, self SampleToChunkEntry) {
 const LenSampleToChunkEntry = 12
 
 type CompositionOffset struct {
-	Version	uint8
-	Flags	uint32
-	Entries	[]CompositionOffsetEntry
+	Version uint8
+	Flags   uint32
+	Entries []CompositionOffsetEntry
 	AtomPos
 }
 
 func (self CompositionOffset) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(CTTS))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -2408,7 +2426,7 @@ func (self CompositionOffset) Len() (n int) {
 	n += 1
 	n += 3
 	n += 4
-	n += LenCompositionOffsetEntry*len(self.Entries)
+	n += LenCompositionOffsetEntry * len(self.Entries)
 	return
 }
 func (self *CompositionOffset) Unmarshal(b []byte, offset int) (n int, err error) {
@@ -2445,8 +2463,8 @@ func (self CompositionOffset) Children() (r []Atom) {
 }
 
 type CompositionOffsetEntry struct {
-	Count	uint32
-	Offset	uint32
+	Count  uint32
+	Offset uint32
 }
 
 func GetCompositionOffsetEntry(b []byte) (self CompositionOffsetEntry) {
@@ -2462,15 +2480,15 @@ func PutCompositionOffsetEntry(b []byte, self CompositionOffsetEntry) {
 const LenCompositionOffsetEntry = 8
 
 type SyncSample struct {
-	Version	uint8
-	Flags	uint32
-	Entries	[]uint32
+	Version uint8
+	Flags   uint32
+	Entries []uint32
 	AtomPos
 }
 
 func (self SyncSample) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(STSS))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -2492,7 +2510,7 @@ func (self SyncSample) Len() (n int) {
 	n += 1
 	n += 3
 	n += 4
-	n += 4*len(self.Entries)
+	n += 4 * len(self.Entries)
 	return
 }
 func (self *SyncSample) Unmarshal(b []byte, offset int) (n int, err error) {
@@ -2529,15 +2547,15 @@ func (self SyncSample) Children() (r []Atom) {
 }
 
 type ChunkOffset struct {
-	Version	uint8
-	Flags	uint32
-	Entries	[]uint32
+	Version uint8
+	Flags   uint32
+	Entries []uint32
 	AtomPos
 }
 
 func (self ChunkOffset) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(STCO))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -2559,7 +2577,7 @@ func (self ChunkOffset) Len() (n int) {
 	n += 1
 	n += 3
 	n += 4
-	n += 4*len(self.Entries)
+	n += 4 * len(self.Entries)
 	return
 }
 func (self *ChunkOffset) Unmarshal(b []byte, offset int) (n int, err error) {
@@ -2596,15 +2614,15 @@ func (self ChunkOffset) Children() (r []Atom) {
 }
 
 type MovieFrag struct {
-	Header		*MovieFragHeader
-	Tracks		[]*TrackFrag
-	Unknowns	[]Atom
+	Header   *MovieFragHeader
+	Tracks   []*TrackFrag
+	Unknowns []Atom
 	AtomPos
 }
 
 func (self MovieFrag) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(MOOF))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -2664,7 +2682,7 @@ func (self *MovieFrag) Unmarshal(b []byte, offset int) (n int, err error) {
 			}
 		default:
 			{
-				atom := &Dummy{Tag_: tag, Data: b[n:n+size]}
+				atom := &Dummy{Tag_: tag, Data: b[n : n+size]}
 				if _, err = atom.Unmarshal(b[n:n+size], offset+n); err != nil {
 					err = parseErr("", n+offset, err)
 					return
@@ -2688,15 +2706,15 @@ func (self MovieFrag) Children() (r []Atom) {
 }
 
 type MovieFragHeader struct {
-	Version	uint8
-	Flags	uint32
-	Seqnum	uint32
+	Version uint8
+	Flags   uint32
+	Seqnum  uint32
 	AtomPos
 }
 
 func (self MovieFragHeader) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(MFHD))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -2744,16 +2762,16 @@ func (self MovieFragHeader) Children() (r []Atom) {
 }
 
 type TrackFrag struct {
-	Header		*TrackFragHeader
-	DecodeTime	*TrackFragDecodeTime
-	Run		*TrackFragRun
-	Unknowns	[]Atom
+	Header     *TrackFragHeader
+	DecodeTime *TrackFragDecodeTime
+	Run        *TrackFragRun
+	Unknowns   []Atom
 	AtomPos
 }
 
 func (self TrackFrag) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(TRAF))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -2828,7 +2846,7 @@ func (self *TrackFrag) Unmarshal(b []byte, offset int) (n int, err error) {
 			}
 		default:
 			{
-				atom := &Dummy{Tag_: tag, Data: b[n:n+size]}
+				atom := &Dummy{Tag_: tag, Data: b[n : n+size]}
 				if _, err = atom.Unmarshal(b[n:n+size], offset+n); err != nil {
 					err = parseErr("", n+offset, err)
 					return
@@ -2855,14 +2873,14 @@ func (self TrackFrag) Children() (r []Atom) {
 }
 
 type MovieExtend struct {
-	Tracks		[]*TrackExtend
-	Unknowns	[]Atom
+	Tracks   []*TrackExtend
+	Unknowns []Atom
 	AtomPos
 }
 
 func (self MovieExtend) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(MVEX))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -2907,7 +2925,7 @@ func (self *MovieExtend) Unmarshal(b []byte, offset int) (n int, err error) {
 			}
 		default:
 			{
-				atom := &Dummy{Tag_: tag, Data: b[n:n+size]}
+				atom := &Dummy{Tag_: tag, Data: b[n : n+size]}
 				if _, err = atom.Unmarshal(b[n:n+size], offset+n); err != nil {
 					err = parseErr("", n+offset, err)
 					return
@@ -2928,19 +2946,19 @@ func (self MovieExtend) Children() (r []Atom) {
 }
 
 type TrackExtend struct {
-	Version			uint8
-	Flags			uint32
-	TrackId			uint32
-	DefaultSampleDescIdx	uint32
-	DefaultSampleDuration	uint32
-	DefaultSampleSize	uint32
-	DefaultSampleFlags	uint32
+	Version               uint8
+	Flags                 uint32
+	TrackId               uint32
+	DefaultSampleDescIdx  uint32
+	DefaultSampleDuration uint32
+	DefaultSampleSize     uint32
+	DefaultSampleFlags    uint32
 	AtomPos
 }
 
 func (self TrackExtend) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(TREX))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -3024,16 +3042,16 @@ func (self TrackExtend) Children() (r []Atom) {
 }
 
 type SampleSize struct {
-	Version		uint8
-	Flags		uint32
-	SampleSize	uint32
-	Entries		[]uint32
+	Version    uint8
+	Flags      uint32
+	SampleSize uint32
+	Entries    []uint32
 	AtomPos
 }
 
 func (self SampleSize) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(STSZ))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -3064,7 +3082,7 @@ func (self SampleSize) Len() (n int) {
 		return
 	}
 	n += 4
-	n += 4*len(self.Entries)
+	n += 4 * len(self.Entries)
 	return
 }
 func (self *SampleSize) Unmarshal(b []byte, offset int) (n int, err error) {
@@ -3110,17 +3128,17 @@ func (self SampleSize) Children() (r []Atom) {
 }
 
 type TrackFragRun struct {
-	Version			uint8
-	Flags			uint32
-	DataOffset		uint32
-	FirstSampleFlags	uint32
-	Entries			[]TrackFragRunEntry
+	Version          uint8
+	Flags            uint32
+	DataOffset       uint32
+	FirstSampleFlags uint32
+	Entries          []TrackFragRunEntry
 	AtomPos
 }
 
 func (self TrackFragRun) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(TRUN))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -3151,19 +3169,24 @@ func (self TrackFragRun) marshal(b []byte) (n int) {
 		} else {
 			flags = self.FirstSampleFlags
 		}
+		//log.Printf("TRUN entry[%v]: flags = %v", i, flags)
 		if flags&TRUN_SAMPLE_DURATION != 0 {
+			//log.Printf("TRUN entry[%v]: TRUN_SAMPLE_DURATION = %v, flags = %v", i, entry.Duration, flags)
 			pio.PutU32BE(b[n:], entry.Duration)
 			n += 4
 		}
 		if flags&TRUN_SAMPLE_SIZE != 0 {
+			//log.Printf("TRUN entry[%v]: TRUN_SAMPLE_SIZE = %v, flags = %v", i, entry.Size, flags)
 			pio.PutU32BE(b[n:], entry.Size)
 			n += 4
 		}
 		if flags&TRUN_SAMPLE_FLAGS != 0 {
+			//log.Printf("TRUN entry[%v]: TRUN_SAMPLE_FLAGS = %v, flags = %v", i, entry.Flags, flags)
 			pio.PutU32BE(b[n:], entry.Flags)
 			n += 4
 		}
 		if flags&TRUN_SAMPLE_CTS != 0 {
+			//log.Printf("TRUN entry[%v]: TRUN_SAMPLE_CTS = %v, flags = %v", i, entry.Cts, flags)
 			pio.PutU32BE(b[n:], entry.Cts)
 			n += 4
 		}
@@ -3176,14 +3199,10 @@ func (self TrackFragRun) Len() (n int) {
 	n += 3
 	n += 4
 	if self.Flags&TRUN_DATA_OFFSET != 0 {
-		{
-			n += 4
-		}
+		n += 4
 	}
 	if self.Flags&TRUN_FIRST_SAMPLE_FLAGS != 0 {
-		{
-			n += 4
-		}
+		n += 4
 	}
 
 	for i := range self.Entries {
@@ -3280,10 +3299,10 @@ func (self TrackFragRun) Children() (r []Atom) {
 }
 
 type TrackFragRunEntry struct {
-	Duration	uint32
-	Size		uint32
-	Flags		uint32
-	Cts		uint32
+	Duration uint32
+	Size     uint32
+	Flags    uint32
+	Cts      uint32
 }
 
 func GetTrackFragRunEntry(b []byte) (self TrackFragRunEntry) {
@@ -3303,19 +3322,20 @@ func PutTrackFragRunEntry(b []byte, self TrackFragRunEntry) {
 const LenTrackFragRunEntry = 16
 
 type TrackFragHeader struct {
-	Version		uint8
-	Flags		uint32
-	BaseDataOffset	uint64
-	StsdId		uint32
-	DefaultDuration	uint32
-	DefaultSize	uint32
-	DefaultFlags	uint32
+	Version         uint8
+	Flags           uint32
+	TrackId         uint32
+	BaseDataOffset  uint64
+	StsdId          uint32
+	DefaultDuration uint32
+	DefaultSize     uint32
+	DefaultFlags    uint32
 	AtomPos
 }
 
 func (self TrackFragHeader) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(TFHD))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -3324,18 +3344,22 @@ func (self TrackFragHeader) marshal(b []byte) (n int) {
 	n += 1
 	pio.PutU24BE(b[n:], self.Flags)
 	n += 3
+	pio.PutU32BE(b[n:], self.TrackId)
+	n += 4
 	if self.Flags&TFHD_BASE_DATA_OFFSET != 0 {
 		{
 			pio.PutU64BE(b[n:], self.BaseDataOffset)
 			n += 8
 		}
 	}
+
 	if self.Flags&TFHD_STSD_ID != 0 {
 		{
 			pio.PutU32BE(b[n:], self.StsdId)
 			n += 4
 		}
 	}
+
 	if self.Flags&TFHD_DEFAULT_DURATION != 0 {
 		{
 			pio.PutU32BE(b[n:], self.DefaultDuration)
@@ -3360,6 +3384,7 @@ func (self TrackFragHeader) Len() (n int) {
 	n += 8
 	n += 1
 	n += 3
+	n += 4
 	if self.Flags&TFHD_BASE_DATA_OFFSET != 0 {
 		{
 			n += 8
@@ -3402,6 +3427,14 @@ func (self *TrackFragHeader) Unmarshal(b []byte, offset int) (n int, err error) 
 	}
 	self.Flags = pio.U24BE(b[n:])
 	n += 3
+
+	if len(b) < n+4 {
+		err = parseErr("TrackId", n+offset, err)
+		return
+	}
+	self.TrackId = pio.U32BE(b[n:])
+	n += 4
+
 	if self.Flags&TFHD_BASE_DATA_OFFSET != 0 {
 		{
 			if len(b) < n+8 {
@@ -3459,15 +3492,15 @@ func (self TrackFragHeader) Children() (r []Atom) {
 }
 
 type TrackFragDecodeTime struct {
-	Version	uint8
-	Flags	uint32
-	Time	time.Time
+	Version    uint8
+	Flags      uint32
+	DecodeTime uint64
 	AtomPos
 }
 
 func (self TrackFragDecodeTime) Marshal(b []byte) (n int) {
 	pio.PutU32BE(b[4:], uint32(TFDT))
-	n += self.marshal(b[8:])+8
+	n += self.marshal(b[8:]) + 8
 	pio.PutU32BE(b[0:], uint32(n))
 	return
 }
@@ -3477,11 +3510,11 @@ func (self TrackFragDecodeTime) marshal(b []byte) (n int) {
 	pio.PutU24BE(b[n:], self.Flags)
 	n += 3
 	if self.Version != 0 {
-		PutTime64(b[n:], self.Time)
+		pio.PutU64BE(b[n:], self.DecodeTime)
 		n += 8
 	} else {
 
-		PutTime32(b[n:], self.Time)
+		pio.PutU32BE(b[n:], uint32(self.DecodeTime))
 		n += 4
 	}
 	return
@@ -3514,11 +3547,11 @@ func (self *TrackFragDecodeTime) Unmarshal(b []byte, offset int) (n int, err err
 	self.Flags = pio.U24BE(b[n:])
 	n += 3
 	if self.Version != 0 {
-		self.Time = GetTime64(b[n:])
+		self.DecodeTime = pio.U64BE(b[n:])
 		n += 8
 	} else {
 
-		self.Time = GetTime32(b[n:])
+		self.DecodeTime = uint64(pio.U32BE(b[n:]))
 		n += 4
 	}
 	return


### PR DESCRIPTION
Important note: filtetype must end in fmp4 to be recognized as fragmented mp4. This can be improved.

feature:      FragmentedMP4: added a muxer to create fragmented MP4's
docs:          FragmentedMP4: example was added that converts MP4 to fMP4
bug: 	  TrackFragHeader: fix missing TrackId not being encoded
bug: 	  TrackFragDecodeTime: decode time was not properly encoded
bug: 	  ElemStreamDesc: faulty length calculation (3 addition bytes  ESID + ESFlags) caused broken audio
