### PR TITLE
fix(h264parser): SplitNALUs slice overflow

### DIFF
--- a/codec/h264parser/parser.go
+++ b/codec/h264parser/parser.go
@@ -229,6 +229,9 @@ func SplitNALUs(b []byte) (nalus [][]byte, typ int) {
 		nalus := [][]byte{}
 		for {
 			nalus = append(nalus, _b[:_val4])
+			if _val4 > uint32(len(_b)) {
+				break
+			}
 			_b = _b[_val4:]
 			if len(_b) < 4 {
 				break


### PR DESCRIPTION
SplitNALUs is used in the RTSP code, can cause panics.

more details in https://github.com/RealKeyboardWarrior/joy4/pull/3 :) 